### PR TITLE
Shell hook - leave no trace in user's shell environment

### DIFF
--- a/flakeModules/agenix-shell.nix
+++ b/flakeModules/agenix-shell.nix
@@ -137,7 +137,7 @@ in {
             done
 
             if test "''${#__agenix_shell_identities[@]}" -eq 0; then
-              echo "[agenix] WARNING: no readable identities found!"
+              echo 1>&2 "[agenix] WARNING: no readable identities found!"
             fi
 
             mkdir -p "${cfg.secretsPath}"
@@ -166,11 +166,11 @@ in {
             umask u=r,g=,o=
 
             if ! test -f "${secret.file}"; then
-              echo '[agenix] WARNING: encrypted file ${secret.file} does not exist!'
+              echo 1>&2 '[agenix] WARNING: encrypted file ${secret.file} does not exist!'
             fi
 
             if ! test -d "$(dirname "$__agenix_shell_secret_path")"; then
-              echo "[agenix] WARNING: $(dirname "$__agenix_shell_secret_path") does not exist!"
+              echo 1>&2 "[agenix] WARNING: $(dirname "$__agenix_shell_secret_path") does not exist!"
             fi
 
             LANG=${config.i18n.defaultLocale or "C"} ${lib.getExe config.agenix-shell.agePackage} --decrypt "''${__agenix_shell_identities[@]}" -o "$__agenix_shell_secret_path" "${secret.file}"

--- a/flakeModules/agenix-shell.nix
+++ b/flakeModules/agenix-shell.nix
@@ -102,7 +102,7 @@ in {
             rm -rf "${cfg.secretsPath}"
 
             __agenix_shell_identities=()
-            # shellcheck disable=2043
+            # shellcheck disable=2043,2066
             for __agenix_shell_identity in ${builtins.toString cfg.identityPaths}; do
               test -r "$__agenix_shell_identity" || continue
               __agenix_shell_identities+=(-i "$__agenix_shell_identity")

--- a/flakeModules/agenix-shell.nix
+++ b/flakeModules/agenix-shell.nix
@@ -12,7 +12,8 @@
   duplicateAttrValues = let
     incrAttr = name: value: attrs: let
       valueStr = builtins.unsafeDiscardStringContext (toString value);
-    in attrs // {${valueStr} = (attrs.${valueStr} or []) ++ [name];};
+    in
+      attrs // {${valueStr} = (attrs.${valueStr} or []) ++ [name];};
     incrAttrs = name: values: attrs: lib.pipe attrs (map (incrAttr name) values);
     getAttrValues = attrs: map (lib.flip lib.getAttr attrs);
   in

--- a/flakeModules/agenix-shell.nix
+++ b/flakeModules/agenix-shell.nix
@@ -101,40 +101,45 @@ in {
             # shellcheck disable=SC2086
             rm -rf "${cfg.secretsPath}"
 
-            IDENTITIES=()
+            __agenix_shell_identities=()
             # shellcheck disable=2043
-            for identity in ${builtins.toString cfg.identityPaths}; do
-              test -r "$identity" || continue
-              IDENTITIES+=(-i)
-              IDENTITIES+=("$identity")
+            for __agenix_shell_identity in ${builtins.toString cfg.identityPaths}; do
+              test -r "$__agenix_shell_identity" || continue
+              __agenix_shell_identities+=(-i "$__agenix_shell_identity")
             done
 
-            test "''${#IDENTITIES[@]}" -eq 0 && echo "[agenix] WARNING: no readable identities found!"
+            test "''${#__agenix_shell_identities[@]}" -eq 0 && echo "[agenix] WARNING: no readable identities found!"
 
             mkdir -p "${cfg.secretsPath}"
           ''
-          + lib.concatStrings (lib.mapAttrsToList (_: config.agenix-shell._installSecret) cfg.secrets);
+          + lib.concatStrings (lib.mapAttrsToList (_: config.agenix-shell._installSecret) cfg.secrets)
+          + ''
+            # Clean up after ourselves
+            # shellcheck disable=SC2154
+            unset "''${!__agenix_shell_@}" || :
+          '';
       };
 
       _installSecret = mkOption {
         type = types.functionTo types.str;
         internal = true;
         default = secret: ''
-          SECRET_PATH=${secret.path}
+          __agenix_shell_secret_path=${secret.path}
 
           # shellcheck disable=SC2193
-          [ "$SECRET_PATH" != "${cfg.secretsPath}/${secret.name}" ] && mkdir -p "$(dirname "$SECRET_PATH")"
+          [ "$__agenix_shell_secret_path" != "${cfg.secretsPath}/${secret.name}" ] && mkdir -p "$(dirname "$__agenix_shell_secret_path")"
+
           (
             umask u=r,g=,o=
             test -f "${secret.file}" || echo '[agenix] WARNING: encrypted file ${secret.file} does not exist!'
-            test -d "$(dirname "$SECRET_PATH")" || echo "[agenix] WARNING: $(dirname "$SECRET_PATH") does not exist!"
-            LANG=${config.i18n.defaultLocale or "C"} ${lib.getExe config.agenix-shell.agePackage} --decrypt "''${IDENTITIES[@]}" -o "$SECRET_PATH" "${secret.file}"
+            test -d "$(dirname "$__agenix_shell_secret_path")" || echo "[agenix] WARNING: $(dirname "$__agenix_shell_secret_path") does not exist!"
+            LANG=${config.i18n.defaultLocale or "C"} ${lib.getExe config.agenix-shell.agePackage} --decrypt "''${__agenix_shell_identities[@]}" -o "$__agenix_shell_secret_path" "${secret.file}"
           )
 
-          chmod ${secret.mode} "$SECRET_PATH"
+          chmod ${secret.mode} "$__agenix_shell_secret_path"
 
-          ${secret.name}=$(cat "$SECRET_PATH")
-          ${secret.namePath}="$SECRET_PATH"
+          ${secret.name}=$(cat "$__agenix_shell_secret_path")
+          ${secret.namePath}="$__agenix_shell_secret_path"
           export ${secret.name}
           export ${secret.namePath}
         '';

--- a/flakeModules/agenix-shell.nix
+++ b/flakeModules/agenix-shell.nix
@@ -42,7 +42,7 @@
 
       namePath = mkOption {
         type = shellVarType;
-        default = toShellVar "${config._module.args.name}_PATH";
+        default = "${config.name}_PATH";
         description = "Name of the variable containing the path to the secret.";
         defaultText = lib.literalExpression "<name>_PATH";
       };

--- a/flakeModules/agenix-shell.nix
+++ b/flakeModules/agenix-shell.nix
@@ -120,6 +120,7 @@ in {
       _installSecrets = mkOption {
         type = types.str;
         internal = true;
+        readOnly = true;
         default =
           ''
             # shellcheck disable=SC2086
@@ -147,6 +148,7 @@ in {
       _installSecret = mkOption {
         type = types.functionTo types.str;
         internal = true;
+        readOnly = true;
         default = secret: ''
           __agenix_shell_secret_path=${secret.path}
 


### PR DESCRIPTION
Thanks for this handy tool; it's exactly what I need for managing secrets in my devshell :).

This PR addresses several issues I encountered  while integrating this into my main NixOS configuration flake.  Summary of changes:

1. "Namespace" the shell hook's variables by prepending `__agenix_shell_` to their names; additionally, unset all such variables as the final action of the hook, thus preventing them from hanging around in the devshell environment.
2. Stop `shellcheck` from complaining about a `for` loop with a single iteration item, which happens when `agenix-shell.secrets.<name>.identityPaths` contains only one item.
3. Escape the default values of `agenix-shell.secrets.<name>.name` and `agenix-shell.secrets.<name>.namePath` (in what I hope is a reasonably-sane manner) such that they are usable as shell variable names even when `_module.args.name` is not.
4. Prevent the shell hook from altering shell options (in particular, it stops it from enabling `errexit`, `nounset`, and `pipefail`).
5. Handle `errexit` (when set by the user) by replacing boolean conjunctions with `if`s.

Other minor/incidental changes:

1. Mark the `_installSecret` and `_installSecrets` option as read-only.  These are already marked as "internal", and are only set once.
2. Replace boolean disjunctions with `if`s, for consistency with the changes mentioned in item 5, above.
3. Harmonize the default values of `agenix-shell.secrets.<name>.name` and `agenix-shell.secrets.<name>.namePath` by making the latter's default value `${config.name}_PATH` rather than `${config._module.args.name}_PATH`.

Thanks in advance for your consideration!