### PR TITLE
Secret-decryption diagnostic messages 

### DIFF
--- a/flakeModules/agenix-shell.nix
+++ b/flakeModules/agenix-shell.nix
@@ -181,7 +181,7 @@ in {
 
             mkdir -p "${cfg.secretsPath}"
           ''
-          + lib.concatStrings (lib.mapAttrsToList (_: config.agenix-shell._installSecret) cfg.secrets)
+          + lib.concatStrings (lib.mapAttrsToList config.agenix-shell._installSecret cfg.secrets)
           + ''
             # Clean up after ourselves
             # shellcheck disable=SC2154
@@ -190,11 +190,13 @@ in {
       };
 
       _installSecret = mkOption {
-        type = types.functionTo types.str;
+        type = types.functionTo (types.functionTo types.str);
         internal = true;
         readOnly = true;
-        default = secret: ''
+        default = name: secret: ''
           __agenix_shell_secret_path=${secret.path}
+
+          printf 1>&2 -- '[agenix] decrypting secret %q from %q to %q...\n' ${lib.escapeShellArgs [name secret.file]} "$__agenix_shell_secret_path"
 
           # shellcheck disable=SC2193
           if [ "$__agenix_shell_secret_path" != "${cfg.secretsPath}/${secret.name}" ]; then


### PR DESCRIPTION
Show secret name and {en,de}crypted path when running the devshell hook script, mimicking the behavior of the `agenix` activation snippets.