### PR TITLE
flakeModules/agenix-shell: Forward local flake inputs

### DIFF
--- a/flakeModules/agenix-shell.nix
+++ b/flakeModules/agenix-shell.nix
@@ -1,5 +1,4 @@
-{ localInputs }:
-{
+{localInputs}: {
   config,
   lib,
   flake-parts-lib,

--- a/flakeModules/agenix-shell.nix
+++ b/flakeModules/agenix-shell.nix
@@ -1,8 +1,8 @@
+{ localInputs }:
 {
   config,
   lib,
   flake-parts-lib,
-  inputs,
   ...
 }: let
   inherit (lib) mkOption mkPackageOption types;
@@ -80,7 +80,7 @@
   });
 in {
   imports = [
-    inputs.flake-root.flakeModule
+    localInputs.flake-root.flakeModule
   ];
 
   options.agenix-shell = {

--- a/flakeModules/default.nix
+++ b/flakeModules/default.nix
@@ -1,6 +1,11 @@
-{config, inputs, flake-parts-lib, ...}: {
+{
+  config,
+  inputs,
+  flake-parts-lib,
+  ...
+}: {
   flake.flakeModules = {
-    agenix-shell = flake-parts-lib.importApply ./agenix-shell.nix { localInputs = inputs; };
+    agenix-shell = flake-parts-lib.importApply ./agenix-shell.nix {localInputs = inputs;};
     default = config.flake.flakeModules.agenix-shell;
   };
 }

--- a/flakeModules/default.nix
+++ b/flakeModules/default.nix
@@ -1,6 +1,6 @@
-{config, ...}: {
+{config, inputs, flake-parts-lib, ...}: {
   flake.flakeModules = {
-    agenix-shell = ./agenix-shell.nix;
+    agenix-shell = flake-parts-lib.importApply ./agenix-shell.nix { localInputs = inputs; };
     default = config.flake.flakeModules.agenix-shell;
   };
 }

--- a/formatting/default.nix
+++ b/formatting/default.nix
@@ -4,11 +4,7 @@
     inputs.git-hooks-nix.flakeModule
   ];
 
-  perSystem = {
-    config,
-    pkgs,
-    ...
-  }: {
+  perSystem = {config, ...}: {
     treefmt.config = {
       projectRootFile = ".git/config";
       flakeFormatter = true;

--- a/templates/flake-parts/flake.nix
+++ b/templates/flake-parts/flake.nix
@@ -5,7 +5,6 @@
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
     flake-parts.url = "github:hercules-ci/flake-parts";
     agenix-shell.url = "github:aciceri/agenix-shell";
-    flake-root.url = "github:srid/flake-root";
   };
 
   outputs = inputs:
@@ -14,7 +13,6 @@
 
       imports = [
         inputs.agenix-shell.flakeModules.default
-        inputs.flake-root.flakeModule
       ];
 
       agenix-shell = {


### PR DESCRIPTION
This way the flake keeps working according to the instructions, without having to specify `inputs.flake-root`.

Alternatively we could update flake.parts-website to unblock the build, but I figured this would do the job.