### PR TITLE
Added devShell for import

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,10 @@ Internally, this approach uses `flake-parts` for argument evaluation. Refer to t
       shellHook = ''
         source ${lib.getExe config.agenix-shell.installationScript}
       '';
+      # or
+      inputsFrom = [
+        config.agenix-shell.devShell
+      ];
     };
   };
 }
@@ -106,7 +110,8 @@ nix flake init -t github:aciceri/agenix-shell#devenv
 ## How It Works
 
 The functionality is straightforward:
-1. `agenix-shell` exports a configurable script, which is sourced in the `devShell` (e.g. via a `shellHook`).
+1. `agenix-shell` exports a configurable script, which is sourced in the `devShell` (e.g. via a `shellHook`),
+  or exports a predefined `devShell`, which can be imported using `inputsFrom`.
 2. The script:
    - Decrypts secrets using the user's SSH keys (default: `$HOME/.ssh/id_rsa` or `$HOME/.ssh/id_ed25519`).
    - Stores decrypted secrets in a secure location:

--- a/flakeModules/agenix-shell.nix
+++ b/flakeModules/agenix-shell.nix
@@ -259,6 +259,7 @@ in {
 
       installationScript = mkOption {
         type = types.package;
+        readOnly = true;
         default = let
           optsSupported = let
             fargs = builtins.functionArgs pkgs.writeShellApplication;
@@ -283,6 +284,18 @@ in {
               bashOptions = [];
             });
         description = "Script that exports secrets as variables, it's meant to be used as hook in `devShell`s.";
+        defaultText = lib.literalMD "An automatically generated package";
+      };
+
+      devShell = mkOption {
+        type = types.package;
+        readOnly = true;
+        default = pkgs.mkShell {
+          name = "agenix-shell-devshell";
+          meta.decryption = "Predefined `devShell` providing a `shellHook`, which setting up the secrets as variables.";
+          shellHook = "source ${lib.getExe config.agenix-shell.installationScript}";
+        };
+        description = "Predefined `devShell` providing a `shellHook`, which setting up the secrets as variables.";
         defaultText = lib.literalMD "An automatically generated package";
       };
     };


### PR DESCRIPTION
Added `devShell` that allows you to import project secrets using the `inputsFrom` attribute. Also updated `README.md` file with new way of loading this shell hook.